### PR TITLE
Add --figure-paths flag to output image file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ arxiv-to-prompt 2307.09288 --section "Human Evaluation"
 # Use path notation when the same name appears multiple times
 arxiv-to-prompt 2307.09288 --section "Fine-tuning > RLHF Results > Human Evaluation"
 
+# Output figure file paths instead of LaTeX text
+arxiv-to-prompt 2303.08774 --figure-paths
+
+# Figure paths from main body only (exclude appendix and commented-out figures)
+arxiv-to-prompt 2303.08774 --figure-paths --no-appendix --no-comments
+
 # Combine with the `llm` library from https://github.com/simonw/llm to chat about the paper
 arxiv-to-prompt 1706.03762 | llm -s "explain this paper"
 ```
@@ -99,6 +105,9 @@ latex_source = process_latex_source("2303.08774", use_cache=False)
 
 # Process LaTeX sources from a local folder (instead of downloading from arXiv)
 latex_source = process_latex_source(local_folder="/path/to/tex/files")
+
+# Get resolved figure file paths instead of LaTeX text
+figure_paths = process_latex_source("2303.08774", figure_paths_only=True)
 ```
 
 ### Projects Using arxiv-to-prompt

--- a/src/arxiv_to_prompt/__init__.py
+++ b/src/arxiv_to_prompt/__init__.py
@@ -15,7 +15,7 @@ Example:
     >>> latex_source = process_latex_source(local_folder="/path/to/tex/files")
 """
 
-from .core import process_latex_source, download_arxiv_source, get_default_cache_dir, list_sections, extract_section
+from .core import process_latex_source, download_arxiv_source, get_default_cache_dir, list_sections, extract_section, extract_figure_paths
 
 # Import version from package metadata
 try:
@@ -34,5 +34,6 @@ __all__ = [
     "get_default_cache_dir",
     "list_sections",
     "extract_section",
+    "extract_figure_paths",
     "__version__",
 ]

--- a/src/arxiv_to_prompt/cli.py
+++ b/src/arxiv_to_prompt/cli.py
@@ -83,6 +83,12 @@ def main():
         default=120.0,
         help="Seconds to wait for the per-paper cache lock when another process is downloading",
     )
+    parser.add_argument(
+        "--figure-paths",
+        action="store_true",
+        default=False,
+        help="Output resolved figure file paths instead of LaTeX text",
+    )
 
     args = parser.parse_args()
     
@@ -103,6 +109,7 @@ def main():
         remove_appendix_section=args.no_appendix,
         local_folder=args.local_folder,
         lock_timeout_seconds=args.lock_timeout,
+        figure_paths_only=args.figure_paths,
     )
     if not content:
         return


### PR DESCRIPTION
Adds extract_figure_paths() which resolves \includegraphics references to absolute file paths. When --figure-paths is used, outputs image paths instead of LaTeX text. Respects --no-comments and --no-appendix filters.