### PR TITLE
Add --abstract flag to output only the abstract text

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ arxiv-to-prompt 2303.08774 --figure-paths
 # Figure paths from main body only (exclude appendix and commented-out figures)
 arxiv-to-prompt 2303.08774 --figure-paths --no-appendix --no-comments
 
+# Output only the abstract text
+arxiv-to-prompt 2303.08774 --abstract
+
 # Combine with the `llm` library from https://github.com/simonw/llm to chat about the paper
 arxiv-to-prompt 1706.03762 | llm -s "explain this paper"
 ```
@@ -108,6 +111,9 @@ latex_source = process_latex_source(local_folder="/path/to/tex/files")
 
 # Get resolved figure file paths instead of LaTeX text
 figure_paths = process_latex_source("2303.08774", figure_paths_only=True)
+
+# Get only the abstract text
+abstract = process_latex_source("2303.08774", abstract_only=True)
 ```
 
 ### Projects Using arxiv-to-prompt

--- a/src/arxiv_to_prompt/__init__.py
+++ b/src/arxiv_to_prompt/__init__.py
@@ -15,7 +15,7 @@ Example:
     >>> latex_source = process_latex_source(local_folder="/path/to/tex/files")
 """
 
-from .core import process_latex_source, download_arxiv_source, get_default_cache_dir, list_sections, extract_section, extract_figure_paths
+from .core import process_latex_source, download_arxiv_source, get_default_cache_dir, list_sections, extract_section, extract_figure_paths, extract_abstract
 
 # Import version from package metadata
 try:
@@ -35,5 +35,6 @@ __all__ = [
     "list_sections",
     "extract_section",
     "extract_figure_paths",
+    "extract_abstract",
     "__version__",
 ]

--- a/src/arxiv_to_prompt/cli.py
+++ b/src/arxiv_to_prompt/cli.py
@@ -90,14 +90,37 @@ def main():
         help="Output resolved figure file paths instead of LaTeX text",
     )
 
+    parser.add_argument(
+        "--abstract",
+        action="store_true",
+        default=False,
+        help="Output only the abstract text",
+    )
+
     args = parser.parse_args()
-    
+
     # Validate that either arxiv_id or local_folder is provided
     if not args.arxiv_id and not args.local_folder:
         parser.error("Either provide an arXiv ID or use --local-folder to specify a local folder")
-    
+
     if args.arxiv_id and args.local_folder:
         parser.error("Cannot specify both arXiv ID and --local-folder")
+
+    # Validate incompatible flag combinations
+    if args.abstract and args.figure_paths:
+        parser.error("Cannot use both --abstract and --figure-paths")
+    if args.abstract and args.no_comments:
+        parser.error("--abstract already excludes comments to avoid extracting commented-out abstracts")
+    if args.abstract and args.no_appendix:
+        parser.error("Cannot use both --abstract and --no-appendix")
+    if args.abstract and args.section:
+        parser.error("Cannot use both --abstract and --section")
+    if args.abstract and args.list_sections:
+        parser.error("Cannot use both --abstract and --list-sections")
+    if args.figure_paths and args.section:
+        parser.error("Cannot use both --figure-paths and --section")
+    if args.figure_paths and args.list_sections:
+        parser.error("Cannot use both --figure-paths and --list-sections")
 
     arxiv_id = extract_arxiv_id(args.arxiv_id) if args.arxiv_id else None
 
@@ -110,6 +133,7 @@ def main():
         local_folder=args.local_folder,
         lock_timeout_seconds=args.lock_timeout,
         figure_paths_only=args.figure_paths,
+        abstract_only=args.abstract,
     )
     if not content:
         return


### PR DESCRIPTION
Adds extract_abstract() which extracts content between \begin{abstract}...\end{abstract}. Comments are always stripped before extraction to avoid returning commented-out abstracts. Also adds validation to prevent incompatible flag combinations (e.g. --abstract + --figure-paths, --figure-paths + --section).