### PR TITLE
Add --expand-macros flag to expand \newcommand and related macro defi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ arxiv-to-prompt 2303.08774 --figure-paths --no-appendix --no-comments
 # Output only the abstract text
 arxiv-to-prompt 2303.08774 --abstract
 
+# Expand \newcommand and related macro definitions inline
+arxiv-to-prompt 2303.08774 --expand-macros
+
 # Combine with the `llm` library from https://github.com/simonw/llm to chat about the paper
 arxiv-to-prompt 1706.03762 | llm -s "explain this paper"
 ```
@@ -114,6 +117,9 @@ figure_paths = process_latex_source("2303.08774", figure_paths_only=True)
 
 # Get only the abstract text
 abstract = process_latex_source("2303.08774", abstract_only=True)
+
+# Expand custom macro definitions inline
+latex_source = process_latex_source("2303.08774", expand_macros_flag=True)
 ```
 
 ### Projects Using arxiv-to-prompt

--- a/src/arxiv_to_prompt/__init__.py
+++ b/src/arxiv_to_prompt/__init__.py
@@ -15,7 +15,7 @@ Example:
     >>> latex_source = process_latex_source(local_folder="/path/to/tex/files")
 """
 
-from .core import process_latex_source, download_arxiv_source, get_default_cache_dir, list_sections, extract_section, extract_figure_paths, extract_abstract
+from .core import process_latex_source, download_arxiv_source, get_default_cache_dir, list_sections, extract_section, extract_figure_paths, extract_abstract, expand_macros
 
 # Import version from package metadata
 try:
@@ -36,5 +36,6 @@ __all__ = [
     "extract_section",
     "extract_figure_paths",
     "extract_abstract",
+    "expand_macros",
     "__version__",
 ]

--- a/src/arxiv_to_prompt/cli.py
+++ b/src/arxiv_to_prompt/cli.py
@@ -97,6 +97,13 @@ def main():
         help="Output only the abstract text",
     )
 
+    parser.add_argument(
+        "--expand-macros",
+        action="store_true",
+        default=False,
+        help="Expand \\newcommand and related macro definitions inline",
+    )
+
     args = parser.parse_args()
 
     # Validate that either arxiv_id or local_folder is provided
@@ -134,6 +141,7 @@ def main():
         lock_timeout_seconds=args.lock_timeout,
         figure_paths_only=args.figure_paths,
         abstract_only=args.abstract,
+        expand_macros_flag=args.expand_macros,
     )
     if not content:
         return


### PR DESCRIPTION
…nitions inline

Supports \newcommand, \renewcommand, \providecommand (and starred variants), \DeclareMathOperator (and starred), and basic \def\cmd{body}. Handles zero-arg, multi-arg, and optional-arg macros with nested expansion (up to 10 passes). Definition lines are removed from the output.

Closes #3 